### PR TITLE
Add footer support to Attachment struct

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -13,6 +13,8 @@ type Attachment struct {
 	Fields     []*Field `json:"fields,omitempty"`
 	ImageURL   string   `json:"image_url,omitempty"`
 	ThumbURL   string   `json:"thumb_url,omitempty"`
+	Footer     string   `json:"footer,omitempty"`
+	FooterIcon string   `json:"footer_icon,omitempty"`
 	MarkdownIn []string `json:"mrkdwn_in,omitempty"`
 }
 


### PR DESCRIPTION
https://api.slack.com/docs/message-attachments#creating_attachment_footers
